### PR TITLE
Fix: Ensure process variable holds a string in updateBpmn function

### DIFF
--- a/src/chatbot/BpmnGPT.js
+++ b/src/chatbot/BpmnGPT.js
@@ -198,7 +198,7 @@ export class BpmnGPT {
       }),
       userPrompt: Mustache.render(`Process: {{process}}
 Requested changes: {{requestedChanges}}`, {
-        process,
+        process : JSON.stringify(process, null, 2),
         requestedChanges
       })
     });
@@ -227,7 +227,7 @@ Requested changes: {{requestedChanges}}`, {
           'content': userPrompt
         }
       ],
-      model: 'gpt-4-1106-preview',
+      model: 'gpt-4o',
       response_format: { type: 'json_object' }
     });
 


### PR DESCRIPTION
This pull request addresses a small but crucial issue in the updateBpmn function where the process variable was only holding the string "process" instead of the previous process information. 
This caused the update to result in a completely new BPMN, rather than modifying the existing process as intended.